### PR TITLE
Compatibility fix for JDK9 and up

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>nl.hsac</groupId>
     <artifactId>allure-fitnesse-listener</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.4-SNAPSHOT</version>
     <url>https://github.com/fhoeben/allure-fitnesse-listener</url>
     <name>Allure jUnit Listener for FitNesse</name>
     <description>jUnit Listener to incorporate FitNesse results in Allure</description>
@@ -39,10 +39,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-
-        <fitnesse.version>20161106</fitnesse.version>
-        <hsac.fixtures.version>2.10.2</hsac.fixtures.version>
-        <allure.version>1.5.0</allure.version>
+        <fitnesse.version>20180127</fitnesse.version>
+        <hsac.fixtures.version>3.29.1</hsac.fixtures.version>
+        <allure.version>1.5.4</allure.version>
     </properties>
 
     <dependencies>
@@ -67,6 +66,24 @@
             <groupId>ru.yandex.qatools.allure</groupId>
             <artifactId>allure-java-adaptor-api</artifactId>
             <version>${allure.version}</version>
+        </dependency>
+
+        <!-- jaxb dependencies for JDK9 and up -->
+
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.3.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.3.1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Added jaxb dependencies for JDK9+ compatibility (see also: http://openjdk.java.net/jeps/320) + some dependency version updates